### PR TITLE
fix: performance issue

### DIFF
--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -3,10 +3,6 @@ framework:
         app: cache.adapter.redis
         default_redis_provider: '%env(REDIS_HOST_DSN)%'
         directory: '%kernel.cache_dir%/tiles' # TODO in reality this does not do the thing we want
-        pools:
-            tilesCache:
-                adapters: [ cache.adapter.filesystem ]
-                default_lifetime: 24 hours
 
 when@test:
     framework:

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -27,6 +27,10 @@ framework:
 
     ide: '%env(SYMFONY_FRAMEWORK_IDE)%'
 
+when@prod:
+    framework:
+        http_cache: true
+
 when@test:
     framework:
         test: true

--- a/src/Controller/TilesProxyController.php
+++ b/src/Controller/TilesProxyController.php
@@ -4,48 +4,40 @@ namespace App\Controller;
 
 use App\Entity\Tiles;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class TilesProxyController extends AbstractController
 {
     public function __construct(
         private readonly HttpClientInterface $httpClient,
-        #[Autowire(service: 'tilesCache')]
-        private readonly CacheInterface $tileCache,
         private readonly ?Profiler $profiler,
     ) {
     }
 
+    #[Cache(maxage: 86_400, public: true, mustRevalidate: true)]
     public function __invoke(?Profiler $profiler, Tiles $tiles, string $x, string $y, string $z): Response
     {
         $this->profiler?->disable();
 
         $url = str_replace(['{x}', '{y}', '{z}'], [$x, $y, $z], $tiles->getUrl());
-        $key = sha1($url);
 
-        return $this->tileCache->get($key, function (ItemInterface $item) use ($url): Response {
-            $headers = [];
-            if (str_contains($url, 'data.geopf.fr')) {
-                $headers['Referer'] = 'https://www.geoportail.gouv.fr/';
-            }
-            // $item->expiresAfter(); // framework.cache.default_lifetime should take prevalence
-            $response = $this->httpClient->request('GET', $url, ['headers' => $headers]);
-            try {
-                return new Response(
-                    $response->getContent(false),
-                    $response->getStatusCode(),
-                    $response->getHeaders(false)
-                );
-            } catch (\Exception) {
-                $item->expiresAfter(0); // Do not cache
+        $headers = [];
+        if (str_contains($url, 'data.geopf.fr')) {
+            $headers['Referer'] = 'https://www.geoportail.gouv.fr/';
+        }
 
-                return new Response(status: Response::HTTP_SERVICE_UNAVAILABLE);
-            }
-        });
+        $response = $this->httpClient->request('GET', $url, ['headers' => $headers]);
+        try {
+            return new Response(
+                $response->getContent(false),
+                $response->getStatusCode(),
+                $response->getHeaders(false)
+            );
+        } catch (\Exception) {
+            return new Response(status: Response::HTTP_SERVICE_UNAVAILABLE);
+        }
     }
 }

--- a/src/Entity/Tiles.php
+++ b/src/Entity/Tiles.php
@@ -17,6 +17,7 @@ class Tiles
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups(['leaflet'])]
     private ?int $id = null;
 
     #[Assert\NotBlank]
@@ -89,6 +90,7 @@ class Tiles
         return $this;
     }
 
+    #[Groups(['leaflet'])]
     public function getUrl(): string
     {
         return $this->url;


### PR DESCRIPTION
Fix performance issues
 - use tiles server without proxy (will leak API key in tiles URLs if exist)
 - except when saving offline (needed for CORS)
 - except when using live view (needed for service worker)

fixes #20